### PR TITLE
Add "auto" property to allow components to control when JSONP request is made

### DIFF
--- a/iron-jsonp-library.html
+++ b/iron-jsonp-library.html
@@ -257,7 +257,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       /**
        * Set if the library should load right away or not
        */
-       auto: Object
+      auto: {
+         type: Object,
+         value: true
+       }
     }
   });
 

--- a/iron-jsonp-library.html
+++ b/iron-jsonp-library.html
@@ -95,6 +95,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     ready: function() {
+      if ( this.auto ) {
+        this._loadLibrary();
+      }
+    },
+    
+    generateRequest: function () {
       this._loadLibrary();
     }
   };
@@ -245,14 +251,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       /**
        * event with name specified in 'notifyEvent' attribute
        * will fire upon successful load
-       */
-      notifyEvent: String
-      /**
-       * event with name specified in 'notifyEvent' attribute
-       * will fire upon successful load
        * @event `notifyEvent`
        */
-
+      notifyEvent: String,
+      /**
+       * Set if the library should load right away or not
+       */
+       auto: Object
     }
   });
 


### PR DESCRIPTION
 Added a property "auto" that you can set to true or false that controls if the library is loaded in the "ready" event for the component. (By default it is true - keep backwards compatible).

Disable sample:

``` html
<iron-jsonp-library
    auto="false"
    library-url=""
    callback-name="s7ImageSetLoad"
    notify-event="api-load"
    library-loaded="{{loaded}}"
    library-error-message="{{errorMessage}}">
</iron-jsonp-library>
```

Anywhere in your component you can then call `generateRequest()` to cause the library to load

``` javascript
this.$.ajax.generateRequest();
```

This helps when you may not know the library url at load time.
