### PR TITLE
Move library load out of .ready()

### DIFF
--- a/iron-jsonp-library.html
+++ b/iron-jsonp-library.html
@@ -87,15 +87,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     /** loads the library, and fires this.notifyEvent upon completion */
     _loadLibrary: function() {
-      LoaderMap.require(
-        this.libraryUrl,
-        this._libraryLoadCallback.bind(this),
-        this.callbackName
-      );
-    },
-
-    ready: function() {
-      this._loadLibrary();
+      if (this.libraryUrl) {
+        LoaderMap.require(
+          this.libraryUrl,
+          this._libraryLoadCallback.bind(this),
+          this.callbackName
+        );
+      }
     }
   };
 
@@ -236,7 +234,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * Ex: https://maps.googleapis.com/maps/api/js?callback=%%callback%%
        */
-      libraryUrl: String,
+      libraryUrl: {
+        type: String,
+        value: '',
+        observer: '_loadLibrary'
+      },
       /**
        * Set if library requires specific callback name.
        * Name will be automatically generated if not set.

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -55,6 +55,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.isNotNull(badlibcallback.libraryErrorMessage);
         });
 
+        test('works with document.createElement', function() {
+          var lib = document.createElement('iron-jsonp-library');
+          lib.notifyEvent = 'api-load';
+          lib.libraryUrl =
+              "https://apis.google.com/js/plusone.js?onload=%%callback%%";
+          lib.addEventListener('api-load', function() {
+            assertEqual(lib.libraryLoaded, true);
+            done();
+          });
+        });
+
       });
     </script>
 


### PR DESCRIPTION
When creating iron-jsonp-library with document.createElement the element's .ready() function immediately fires and doesn't actually load anything. By removing .read() and observer the libraryUrl property we can kick off an request when the libraryUrl changes. Fixes https://github.com/PolymerElements/iron-jsonp-library/issues/6
