### PR TITLE
Trigger load on attatched, improve tests

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,6 +30,7 @@
     "web-component-tester": "*",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
     "paper-styles": "PolymerElements/paper-styles#^1.0.2",
-    "paper-spinner": "PolymerElements/paper-spinner#^1.0.1"
+    "paper-spinner": "PolymerElements/paper-spinner#^1.0.1",
+    "promise-polyfill": "polymerlabs/promise-polyfill#^1.0.0"
   }
 }

--- a/iron-jsonp-library.html
+++ b/iron-jsonp-library.html
@@ -94,7 +94,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       );
     },
 
-    ready: function() {
+    attached: function() {
       this._loadLibrary();
     }
   };

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -20,39 +20,43 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <link rel="import" href="../iron-jsonp-library.html">
   </head>
   <body>
-    <iron-jsonp-library id="plusone"
-      library-url="https://apis.google.com/js/plusone.js?onload=%%callback%%"
-      notify-event="api-load"></iron-jsonp-library>
-    <iron-jsonp-library id="badliburl"
-      library-url="https://badapis.google.com/js/plusone.js?onload=%%callback%%"
-      notify-event="api-load"></iron-jsonp-library>
-    <iron-jsonp-library id="badlibcallback"
-      library-url="https://apis.google.com/"
-      notify-event="api-load"></iron-jsonp-library>
-
     <script>
-      var goodLib = document.querySelector('#plusone');
-      var badliburl = document.querySelector('#badliburl');
-      var badlibcallback = document.querySelector('#badlibcallback');
 
       suite('<iron-jsonp-library>', function() {
 
         test('good library loads', function(done) {
+          var goodLib = document.createElement('iron-jsonp-library');
+          goodLib.libraryUrl = 'https://apis.google.com/js/plusone.js' +
+              '?onload=%%callback%%';
+          goodLib.notifyEvent = 'api-load';
           goodLib.addEventListener('api-load', function() {
             assert.equal(goodLib.libraryLoaded, true);
             done();
           });
+          document.body.appendChild(goodLib);
         });
 
-        test('bad library dns fails to load', function() {
-          badliburl.addEventListener('libraryErrorMessage-changed', function() {
-            assert.isNotNull(badliburl.libraryErrorMessage);
+        test('bad library dns fails to load', function(done) {
+          var badLib = document.createElement('iron-jsonp-library');
+          badLib.libraryUrl = 'https://badapis.google.com/js/plusone.js' +
+              '?onload=%%callback%%';
+          badLib.notifyEvent = 'api-load';
+          badLib.addEventListener('library-error-message-changed', function() {
+            assert.isNotNull(badLib.libraryErrorMessage);
             done();
           });
+          document.body.appendChild(badLib);
         });
 
-        test('libraryurl mising %%callback%%', function() {
-          assert.isNotNull(badlibcallback.libraryErrorMessage);
+        test('libraryurl mising %%callback%%', function(done) {
+          var badLib = document.createElement('iron-jsonp-library');
+          badLib.libraryUrl = 'https://apis.google.com/js/plusone.js';
+          badLib.notifyEvent = 'api-load';
+          badLib.addEventListener('library-error-message-changed', function() {
+            assert.isNotNull(badLib.libraryErrorMessage);
+            done();
+          });
+          document.body.appendChild(badLib);
         });
 
       });

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -16,6 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
 
+    <link rel="import" href="../../promise-polyfill/promise-polyfill-lite.html">
     <!-- Step 1: import the element to test -->
     <link rel="import" href="../iron-jsonp-library.html">
   </head>


### PR DESCRIPTION
There was a race in the tests, as the iron-jsonp-library elements began loading as test execution started it was possible that they could finish loading before the tests began. This happened frequently on MS Edge.

Also moved the fetch from ready to attached to be more consistent with other elements (e.g. script, link).
