### PR TITLE
stop bringing in the paper-styles kitchen sink

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
-    "web-component-tester": "*",
+    "web-component-tester": "polymer/web-component-tester#^3.4.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
     "paper-styles": "PolymerElements/paper-styles#^1.0.2",
     "paper-spinner": "PolymerElements/paper-spinner#^1.0.1"

--- a/demo/index.html
+++ b/demo/index.html
@@ -14,7 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
     <title>iron-jsonp-library Demo</title>
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-    <link rel="import" href="../../paper-styles/paper-styles.html">
+    <link rel="import" href="../../paper-styles/color.html">
     <link rel="import" href="../../paper-styles/demo-pages.html">
     <link rel="import" href="../../paper-spinner/paper-spinner.html">
     <link rel="import" href="../iron-jsonp-library.html">

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -15,8 +15,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
-    <script src="../../test-fixture/test-fixture-mocha.js"></script>
-    <link rel="import" href="../../test-fixture/test-fixture.html">
     <link rel="import" href="../iron-jsonp-library.html">
 
   </head>


### PR DESCRIPTION
Fixes the generic usage of `paper-styles.html` and `/deep/` classes and uses the specific imports instead. Also updates the test to the new `wct#^3.4.0` way
