### PR TITLE
Explicitly set _template to null.

### DIFF
--- a/iron-jsonp-library.js
+++ b/iron-jsonp-library.js
@@ -228,6 +228,7 @@ Loader.prototype = {
 Polymer({
 
   is: 'iron-jsonp-library',
+  _template: null,
 
   behaviors: [IronJsonpLibraryBehavior],
 


### PR DESCRIPTION
This lets us skip a querySelector on initial bootup, and makes this code compatible with strictTemplatePolicy.

Internalized as part of cl/218551336